### PR TITLE
Change Drawer position to the right for better responsiveness

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -93,12 +93,12 @@ const Navbar = () => {
       </div>
 
       {/* Drawer for Smaller Screens */}
-      <Drawer anchor="left" open={isDrawerOpen} onClose={toggleDrawer}>
+      <Drawer anchor="right" open={isDrawerOpen} onClose={toggleDrawer}>
         <div className="w-max p-4 flex flex-col items-end bg-gray-50  h-full">
           <IconButton onClick={toggleDrawer} aria-label="close drawer">
             <CloseIcon fontSize="large" />
           </IconButton>
-          <ul className="w-96 flex flex-col items-center justify-around font-medium  text-xl h-1/2 mt-4 space-y-4">
+          <ul className="w-screen md:w-96  flex flex-col items-center justify-around font-medium  text-xl h-1/2 mt-4 space-y-4">
             {navLinks.map((link) => (
               <li key={link.label}>
                 <Link


### PR DESCRIPTION
Adjust the Drawer component's position to the right and modify its width for improved responsiveness on smaller screens.