### PR TITLE
Remove conditional check for cleanup step in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,6 @@ jobs:
 EOF
 
       - name: Cleanup
-        if: always()  # Ensure cleanup runs even if previous steps fail
         run: |
           rm -f ~/.ssh/lightsail_key
           rm -f ~/.ssh/known_hosts


### PR DESCRIPTION
Eliminate the conditional check to ensure the cleanup step always runs during the deployment workflow.